### PR TITLE
Remove dead code

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -103,17 +103,6 @@ impl CorrectedDataStream {
     }
 }
 
-/* ***********************************************************************
- * Decoder algorithm
- */
-#[derive(Copy, Clone)]
-pub struct DataStream {
-    pub raw: [u8; MAX_PAYLOAD_SIZE],
-    pub data_bits: usize,
-    pub ptr: usize,
-    pub data: [u8; MAX_PAYLOAD_SIZE],
-}
-
 /// Given a grid try to decode and write it to the output writer
 ///
 /// This tries to read the bit patterns from a [Grid](trait.Grid.html), correct

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -24,13 +24,6 @@ pub struct CapStone {
     pub c: Perspective,
 }
 
-#[derive(Debug, Clone)]
-pub struct PolygonScoreData {
-    pub ref_0: Point,
-    pub scores: [i32; 4],
-    pub corners: [Point; 4],
-}
-
 /// Find all 'capstones' in a given image.
 ///
 /// A Capstones is the locator pattern of a QR code. Every QR code has 3 of

--- a/src/identify/grid.rs
+++ b/src/identify/grid.rs
@@ -16,8 +16,6 @@ use crate::{
 /// normal [Grid](trait.Grid.html) that can be decoded.
 #[derive(Debug, Clone)]
 pub struct SkewedGridLocation {
-    pub caps: [CapStone; 3],
-    pub align: Point,
     pub grid_size: usize,
     pub c: geometry::Perspective,
 }
@@ -101,11 +99,8 @@ impl SkewedGridLocation {
         }
 
         let c = setup_perspective(img, &group, align, grid_size)?;
-        let caps = [group.0, group.1, group.2];
 
         Some(SkewedGridLocation {
-            align,
-            caps,
             grid_size,
             c,
         })


### PR DESCRIPTION
This pull request includes several changes across different files to remove unused structures and fields, thereby simplifying the codebase. The most important changes involve the removal of the `DataStream` struct from `decode.rs`, the `PolygonScoreData` struct from `detect.rs`, and the `caps` field from the `SkewedGridLocation` struct in `grid.rs`.

Codebase simplification:

* [`src/decode.rs`](diffhunk://#diff-aeece9508d349335fdebc30632ef26fa2851aa73336dea735c78d36cb7e77b2bL106-L116): Removed the `DataStream` struct, which included fields like `raw`, `data_bits`, `ptr`, and `data`.
* [`src/detect.rs`](diffhunk://#diff-da289c982305b981cc1ebfea0a3e9f5fad646be738a9431bd8307e7901663b0fL27-L33): Removed the `PolygonScoreData` struct, which included fields like `ref_0`, `scores`, and `corners`.
* [`src/identify/grid.rs`](diffhunk://#diff-b0a65faa8fad0787e904d90b7c42aadb84e10eb49bc8a38c5b258f9ffcd2f72fL19-L20): Removed the `caps` field from the `SkewedGridLocation` struct and its corresponding initialization in the `impl` block. [[1]](diffhunk://#diff-b0a65faa8fad0787e904d90b7c42aadb84e10eb49bc8a38c5b258f9ffcd2f72fL19-L20) [[2]](diffhunk://#diff-b0a65faa8fad0787e904d90b7c42aadb84e10eb49bc8a38c5b258f9ffcd2f72fL104-L108)